### PR TITLE
adjusted timeout for interlaced sensor read

### DIFF
--- a/sxccd/sxccd.py
+++ b/sxccd/sxccd.py
@@ -125,7 +125,7 @@ class Camera():
 
         write = self.dev.write(0x01, cmd, self.timeout)
         sleep(exp_ms/1000)
-        read = self.dev.read(0x82, 2*nPixels, max(2*exp_ms,5*self.timeout))
+        read = self.dev.read(0x82, 2*nPixels, 5*self.timeout)
 
         image = np.frombuffer(read, dtype=np.uint16).reshape((h, w))
         image = Image.fromarray(image, mode='I;16')


### PR DESCRIPTION
Hi,
firstly thanks for merging my contributions to this repo into master.
I found a little oversight, which is that thereadSensorinterlaced() function uses time.sleep() for setting the exposure time instead of the integrated delay in the usb command /x02 (now /x03 is used). therefore the timeout in the sensor readout can be set to a fix value (which is just kept as the 5*self.timeout that you set) and does not need to account for the exposure time any more.